### PR TITLE
Update to Redmine 4.1.1 and various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ You also have the option to configure these:
 	redmine_proxy: "/etc/nginx/conf.d/redmine_proxy"
 	redmine_public: "{{ redmine_path }}/public"
 	redmine_version: "2.5.2"
+	redmine_bundler_version: "1.17.3"
 	target_dump: "/opt/redmine.sql.bz2"
 	target_files: "/opt/redmine.tar.bz2"
 
 update: Put this true if you have and old version of redmine
 
 nginx: Put this true if you have nginx installed
+
+redmine\_bundler\_version: This specifies the Bundler version. It should be set to a version that is compatible with the given Redmine version. For example, older Redmine versions do not work with Bundler 2.x.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ redmine_files: "{{ redmine_path }}/files"
 #redmine_path: "/opt/redmine"
 redmine_proxy: "/etc/nginx/conf.d/redmine_proxy"
 redmine_public: "{{ redmine_path }}/public"
-redmine_version: "3.1.7"
+redmine_version: "4.1.1"
 redmine_bundler_version: "1.17.3"
 
 target_dump: "/opt/redmine.sql.bz2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ redmine_files: "{{ redmine_path }}/files"
 redmine_proxy: "/etc/nginx/conf.d/redmine_proxy"
 redmine_public: "{{ redmine_path }}/public"
 redmine_version: "3.1.7"
+redmine_bundler_version: "1.17.3"
 
 target_dump: "/opt/redmine.sql.bz2"
 target_files: "/opt/redmine.tar.bz2"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: "Install and Upgrade redmine"
   company: Nomanod
   license: GPLv3
-  min_ansible_version: 1.7
+  min_ansible_version: 2.5
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   when: not update
   
 - name: Install Bundler
-  shell: "gem install bundler"
+  shell: "gem install bundler --version {{ redmine_bundler_version }}"
   args:
     chdir: "{{ redmine_path }}"
   when: not update

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,10 +70,12 @@
    chdir: "{{ redmine_path }}"
   when: not update and redmine_load_default_data|default(false)
 
-- name: Clean up
+- name: Clean up cache
   shell: bundle exec rake tmp:cache:clear
   args:
     chdir: "{{ redmine_path }}"
+
+- name: Clean up sessions
   shell: bundle exec rake tmp:sessions:clear
   args:
     chdir: "{{ redmine_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,7 @@
   shell: bundle exec rake tmp:sessions:clear
   args:
     chdir: "{{ redmine_path }}"
+  when: redmine_version is version_compare('4.0', '<')
 
 
 - name: Copiar Proxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,7 @@
   include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Package pre-requisites
-  apt: name={{ item }} state=latest
-  with_items: "{{ packages }}"
+  apt: name="{{ packages }}" state=latest
 
 - name: Backup database
   mysql_db: name="{{ db_name }}" login_host="{{ db_host }}" \
@@ -79,7 +78,7 @@
   shell: bundle exec rake tmp:sessions:clear
   args:
     chdir: "{{ redmine_path }}"
-  when: redmine_version is version_compare('4.0', '<')
+  when: redmine_version is version('4.0', '<')
 
 
 - name: Copiar Proxy

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,4 +6,4 @@ packages:
   - build-essential
   - ruby-dev
   - libmagickwand-dev
-  - "{{ 'libmariadbclient-dev' if ansible_distribution_version | version_compare('9', '>=') else 'libmysqlclient-dev' }}"
+  - "{{ 'libmariadbclient-dev' if ansible_distribution_version is version('9', '>=') else 'libmysqlclient-dev' }}"


### PR DESCRIPTION
The previous default Redmine version (3.1.7) could not be installed with this role because too recent Bundler (2.x) was installed. Some dependencies required an older version (< 2.0) of Bundler. This request fixes that by specifying an exact Bundler version in a role variable and keeping it on the 1.x series by default.

The clean up task only ran one of the shell commands because a task can only have one action. This request separates them to two tasks.

This request also updates Redmine to the latest version (4.1.1). However, the "tmp:sessions:clear" clean up task was removed from Redmine 4, so running it was made conditional in order to stay compatible with both Redmine 3 and 4.

Finally, some deprecated Ansible features were changed to stay compatible with newer Ansible versions. Unfortunately, this meant that some backwards compatibility was lost. See the commit message for more details.

Sorry for having so many different changes in one pull request. However, splitting them could have been a bit inconvenient as well.